### PR TITLE
Add property-no-unknown rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ module.exports = {
         "media-query-list-comma-space-after": "always",
         "media-query-list-comma-space-before": "never",
         "no-eol-whitespace": true,
+        "property-no-unknown": true,
         "selector-attribute-brackets-space-inside": "never",
         "selector-attribute-operator-space-after": "never",
         "selector-attribute-operator-space-before": "never",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-stylelint-config",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "StyleLint Configuration for AgePartnership's SCSS",
   "main": "index.js",
   "repository": "git@github.com:AgePartnership/ap-stylelint-config.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-stylelint-config",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "StyleLint Configuration for AgePartnership's SCSS",
   "main": "index.js",
   "repository": "git@github.com:AgePartnership/ap-stylelint-config.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-stylelint-config",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "description": "StyleLint Configuration for AgePartnership's SCSS",
   "main": "index.js",
   "repository": "git@github.com:AgePartnership/ap-stylelint-config.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-stylelint-config",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "StyleLint Configuration for AgePartnership's SCSS",
   "main": "index.js",
   "repository": "git@github.com:AgePartnership/ap-stylelint-config.git",


### PR DESCRIPTION
Ticket: https://webjobs.agepartnership.co.uk/desk/tickets/5640682/messages

Changes:
- Add rule to disallow false properties (including typos) as discussed here https://agepartnershipweb.slack.com/archives/CB2PC6HQD/p1626948186000900?thread_ts=1626864609.002300&cid=CB2PC6HQD

Npm installed this branch on https://github.com/AgePartnership/oleg-brand-kit/pull/39 and https://github.com/AgePartnership/web.agepartnership.co.uk/pull/3336 and ran the linter and no false positives were given. Then changed a property in each to be wrong and ran the linter again and it threw and error as expected.

Checks:
- Non-malicious
- Sense