### PR TITLE
Remove block-closing-brace-space-after rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,6 @@ module.exports = {
         "selector-pseudo-element-colon-notation": "double",
         "at-rule-name-space-after": "always",
         "at-rule-semicolon-space-before": "never",
-        "block-closing-brace-space-after": "never-single-line",
         "block-closing-brace-space-before": "always-single-line",
         "block-opening-brace-space-after": "always-single-line",
         "block-opening-brace-space-before": "always",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-stylelint-config",
-  "version": "1.1.0",
+  "version": "1.1.6",
   "description": "StyleLint Configuration for AgePartnership's SCSS",
   "main": "index.js",
   "repository": "git@github.com:AgePartnership/ap-stylelint-config.git",


### PR DESCRIPTION
Ticket: https://webjobs.agepartnership.co.uk/desk/tickets/5668837/messages

Changes:

Remove `block-closing-brace-space-after: never-single-line` rule because this rule combined with `rule-empty-line-before` causes issues in each of the repos and means we have to do this: https://github.com/AgePartnership/oleg-express-brand-kit/pull/42/files#diff-adef1388115c871c91f036b28e1ac17b09cfafbfa3a6b2bf14d354b7339b7267. I.e. we have to add an empty line before the `.lt-ie9.....` rule but then an error gets thrown because the block before is a single line which `block-closing-brace-space-after: never-single-line` doesn't allow to have space after. This means we have to make the change above to make the first block _not_ a single line, so that there can be an empty line after it. 

It seems like an unnecessary rule since we didn't have it in the old sass-lint config, and I think the linked changes are the only ones it makes.

Checks:
- Non-malicious
- Sense